### PR TITLE
GitHub corner is blinking on scroll in Chrome

### DIFF
--- a/src/components/GithubCorner.js
+++ b/src/components/GithubCorner.js
@@ -15,7 +15,7 @@ export default class GithubCorner extends Component {
           style={{
             fill: "#263053",
             color: "#fff",
-            position: "absolute",
+            position: "fixed",
             top: 0,
             border: 0,
             right: 0


### PR DESCRIPTION
Hi there,

github corner is blinking while scrolling in Chrome 59 (MacOS 10.12.5).
Just a proposition to use 'position: fixed' instead of absolute.

P.S. Thanks for cool project 👍